### PR TITLE
Add order checkout feature

### DIFF
--- a/src/Application.Contract/Enums/OrderStatus.cs
+++ b/src/Application.Contract/Enums/OrderStatus.cs
@@ -2,5 +2,7 @@
 
 public enum OrderStatus
 {
-    
+    Opened,
+    Submited,
+    Issued
 }

--- a/src/Application.Contract/Order/Commands/CreateOrderCommand.cs
+++ b/src/Application.Contract/Order/Commands/CreateOrderCommand.cs
@@ -1,0 +1,7 @@
+namespace Application.Contract.Order.Commands;
+
+public class CreateOrderCommand : IRequest<string>
+{
+    public required string ShopSlug { get; set; }
+    public List<CreateOrderItem> Items { get; set; } = new();
+}

--- a/src/Application.Contract/Order/Commands/CreateOrderItem.cs
+++ b/src/Application.Contract/Order/Commands/CreateOrderItem.cs
@@ -1,0 +1,8 @@
+namespace Application.Contract.Order.Commands;
+
+public class CreateOrderItem
+{
+    public required string ProductSlug { get; set; }
+    public int Quantity { get; set; }
+    public string? SelectedVolume { get; set; }
+}

--- a/src/Application.Contract/Order/Commands/UpdateOrderStatusCommand.cs
+++ b/src/Application.Contract/Order/Commands/UpdateOrderStatusCommand.cs
@@ -1,0 +1,9 @@
+namespace Application.Contract.Order.Commands;
+
+using Application.Contract.Enums;
+
+public class UpdateOrderStatusCommand : IRequest<Unit>
+{
+    public required string Slug { get; set; }
+    public OrderStatus Status { get; set; }
+}

--- a/src/Application.Contract/Order/Queries/GetOrderQuery.cs
+++ b/src/Application.Contract/Order/Queries/GetOrderQuery.cs
@@ -1,0 +1,8 @@
+using Application.Contract.Order.Responses;
+
+namespace Application.Contract.Order.Queries;
+
+public class GetOrderQuery : IRequest<OrderResponse>
+{
+    public required string Slug { get; set; }
+}

--- a/src/Application.Contract/Order/Queries/GetOrdersQuery.cs
+++ b/src/Application.Contract/Order/Queries/GetOrdersQuery.cs
@@ -1,0 +1,8 @@
+using Application.Contract.Order.Responses;
+
+namespace Application.Contract.Order.Queries;
+
+public class GetOrdersQuery : IRequest<List<OrderResponse>>
+{
+    public required string ShopSlug { get; set; }
+}

--- a/src/Application.Contract/Order/Responses/OrderResponse.cs
+++ b/src/Application.Contract/Order/Responses/OrderResponse.cs
@@ -1,0 +1,11 @@
+using Application.Contract.Enums;
+
+namespace Application.Contract.Order.Responses;
+
+public class OrderResponse
+{
+    public required string Slug { get; set; }
+    public required string ShopSlug { get; set; }
+    public OrderStatus Status { get; set; }
+    public decimal Sum { get; set; }
+}

--- a/src/Application/Common/Interfaces/Contexts/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/Contexts/IApplicationDbContext.cs
@@ -13,6 +13,8 @@ public interface IApplicationDbContext
     public DbSet<Cart> Carts { get; set; }
     public DbSet<ShopOrder> ShopsOrders { get; set; }
     public DbSet<CartItem> CartItems { get; set; }
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<OrderItem> OrderItems { get; set; }
     public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     public DbSet<ApplicationUser> Users { get; set; }
 }

--- a/src/Application/Features/Orders/Commands/CreateOrderCommandHandler.cs
+++ b/src/Application/Features/Orders/Commands/CreateOrderCommandHandler.cs
@@ -1,0 +1,61 @@
+using Application.Common.Exceptions;
+using Application.Common.Interfaces.Contexts;
+using Application.Common.Interfaces.Services;
+using Application.Contract.Order.Commands;
+using Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Orders.Commands;
+
+public class CreateOrderCommandHandler(
+    IApplicationDbContext context,
+    ISlugService slugService,
+    ICurrentUserService currentUserService)
+    : IRequestHandler<CreateOrderCommand, string>
+{
+    public async Task<string> Handle(CreateOrderCommand request, CancellationToken cancellationToken)
+    {
+        var userName = currentUserService.GetUserName() ?? throw new ForbiddenException();
+
+        var user = await context.Users.FirstOrDefaultAsync(u => u.UserName == userName, cancellationToken)
+                   ?? throw new ForbiddenException();
+
+        var shop = await context.Shops.FirstOrDefaultAsync(s => s.Slug == request.ShopSlug, cancellationToken);
+        if (shop == null)
+            throw new NotFoundException($"The shop with slug {request.ShopSlug} not found.");
+
+        var order = new Domain.Entities.Order
+        {
+            Slug = slugService.GenerateSlug($"{request.ShopSlug}-{userName}-{Guid.NewGuid()}"),
+            ShopId = shop.Id,
+            ShopSlug = shop.Slug,
+            CustomerId = user.Id,
+            Status = OrderStatus.Submited,
+            OrderItems = new List<Domain.Entities.OrderItem>()
+        };
+
+        foreach (var item in request.Items)
+        {
+            var product = await context.Products.FirstOrDefaultAsync(p => p.Slug == item.ProductSlug, cancellationToken)
+                          ?? throw new NotFoundException($"Product {item.ProductSlug} not found.");
+
+            var price = product.DiscountPrice ?? product.Price;
+            var summary = price * item.Quantity;
+
+            order.OrderItems.Add(new Domain.Entities.OrderItem
+            {
+                OrderSlug = order.Slug,
+                ProductId = product.Id,
+                ProductSlug = product.Slug,
+                Quantity = item.Quantity,
+                SummaryPrice = summary,
+                Status = OrderStatus.Submited
+            });
+        }
+
+        await context.Orders.AddAsync(order, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return order.Slug;
+    }
+}

--- a/src/Application/Features/Orders/Commands/UpdateOrderStatusCommandHandler.cs
+++ b/src/Application/Features/Orders/Commands/UpdateOrderStatusCommandHandler.cs
@@ -1,0 +1,34 @@
+using Application.Common.Exceptions;
+using Application.Common.Interfaces.Contexts;
+using Application.Contract.Order.Commands;
+using Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Orders.Commands;
+
+public class UpdateOrderStatusCommandHandler(IApplicationDbContext context)
+    : IRequestHandler<UpdateOrderStatusCommand, Unit>
+{
+    public async Task<Unit> Handle(UpdateOrderStatusCommand request, CancellationToken cancellationToken)
+    {
+        var order = await context.Orders
+            .Include(o => o.OrderItems)
+            .FirstOrDefaultAsync(o => o.Slug == request.Slug, cancellationToken);
+
+        if (order == null)
+            throw new NotFoundException($"Order with slug {request.Slug} not found.");
+
+        order.Status = request.Status;
+        if (order.OrderItems is not null)
+        {
+            foreach (var item in order.OrderItems)
+            {
+                item.Status = request.Status;
+            }
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/Application/Features/Orders/OrderProfile.cs
+++ b/src/Application/Features/Orders/OrderProfile.cs
@@ -1,0 +1,16 @@
+using Application.Contract.Order.Commands;
+using Application.Contract.Order.Queries;
+using Application.Contract.Order.Responses;
+using AutoMapper;
+
+namespace Application.Features.Orders;
+
+public class OrderProfile : Profile
+{
+    public OrderProfile()
+    {
+        CreateMap<CreateOrderCommand, Domain.Entities.Order>();
+        CreateMap<Domain.Entities.Order, OrderResponse>();
+        CreateMap<GetOrderQuery, OrderResponse>();
+    }
+}

--- a/src/Application/Features/Orders/Queries/GetOrderQueryHandler.cs
+++ b/src/Application/Features/Orders/Queries/GetOrderQueryHandler.cs
@@ -1,0 +1,26 @@
+using Application.Common.Exceptions;
+using Application.Common.Interfaces.Contexts;
+using Application.Contract.Order.Queries;
+using Application.Contract.Order.Responses;
+using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Orders.Queries;
+
+public class GetOrderQueryHandler(IApplicationDbContext context, IMapper mapper)
+    : IRequestHandler<GetOrderQuery, OrderResponse>
+{
+    public async Task<OrderResponse> Handle(GetOrderQuery request, CancellationToken cancellationToken)
+    {
+        var order = await context.Orders
+            .FirstOrDefaultAsync(o => o.Slug == request.Slug, cancellationToken);
+
+        if (order == null)
+            throw new NotFoundException($"The order with slug {request.Slug} not found.");
+
+        var response = mapper.Map<OrderResponse>(order);
+        response.Sum = order.OrderItems?.Sum(i => i.SummaryPrice) ?? 0;
+        return response;
+    }
+}

--- a/src/Application/Features/Orders/Queries/GetOrdersQueryHandler.cs
+++ b/src/Application/Features/Orders/Queries/GetOrdersQueryHandler.cs
@@ -1,0 +1,26 @@
+using Application.Common.Interfaces.Contexts;
+using Application.Contract.Order.Queries;
+using Application.Contract.Order.Responses;
+using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace Application.Features.Orders.Queries;
+
+public class GetOrdersQueryHandler(IApplicationDbContext context, IMapper mapper)
+    : IRequestHandler<GetOrdersQuery, List<OrderResponse>>
+{
+    public async Task<List<OrderResponse>> Handle(GetOrdersQuery request, CancellationToken cancellationToken)
+    {
+        var query = context.Orders.AsQueryable();
+        if (!string.IsNullOrEmpty(request.ShopSlug))
+            query = query.Where(o => o.ShopSlug == request.ShopSlug);
+
+        var orders = await query
+            .Select(o => mapper.Map<OrderResponse>(o))
+            .ToListAsync(cancellationToken);
+
+        return orders;
+    }
+}

--- a/src/Client/Client.Infrastructure/Services/DependencyInitializer.cs
+++ b/src/Client/Client.Infrastructure/Services/DependencyInitializer.cs
@@ -20,7 +20,9 @@ public static class DependencyInitializer
             .AddScoped<ICartService, CartService>()
             .AddScoped<IPriceCalculatorService, PriceCalculatorService>()
             .AddScoped<IHttpClientService, HttpClientService>()
-            .AddScoped<IValidationService, ValidationService>();
+            .AddScoped<IValidationService, ValidationService>()
+            .AddScoped<Shop.IShopService, Shop.ShopService>()
+            .AddScoped<Order.IOrderService, Order.OrderService>();
 
     }
 }

--- a/src/Client/Client.Infrastructure/Services/Order/IOrderService.cs
+++ b/src/Client/Client.Infrastructure/Services/Order/IOrderService.cs
@@ -1,0 +1,13 @@
+using Application.Contract.Order.Commands;
+using Application.Contract.Order.Queries;
+using Application.Contract.Order.Responses;
+using Client.Infrastructure.Services.Cart.Models;
+
+namespace Client.Infrastructure.Services.Order;
+
+public interface IOrderService
+{
+    Task<string?> CreateAsync(string shopSlug, IEnumerable<CartItemDto> items);
+    Task<List<OrderResponse>> GetAsync(string shopSlug);
+    Task<OrderResponse?> GetAsyncBySlug(string slug);
+}

--- a/src/Client/Client.Infrastructure/Services/Order/IOrderService.cs
+++ b/src/Client/Client.Infrastructure/Services/Order/IOrderService.cs
@@ -1,6 +1,7 @@
 using Application.Contract.Order.Commands;
 using Application.Contract.Order.Queries;
 using Application.Contract.Order.Responses;
+using Application.Contract.Enums;
 using Client.Infrastructure.Services.Cart.Models;
 
 namespace Client.Infrastructure.Services.Order;
@@ -10,4 +11,5 @@ public interface IOrderService
     Task<string?> CreateAsync(string shopSlug, IEnumerable<CartItemDto> items);
     Task<List<OrderResponse>> GetAsync(string shopSlug);
     Task<OrderResponse?> GetAsyncBySlug(string slug);
+    Task UpdateStatusAsync(string slug, OrderStatus status);
 }

--- a/src/Client/Client.Infrastructure/Services/Order/OrderService.cs
+++ b/src/Client/Client.Infrastructure/Services/Order/OrderService.cs
@@ -1,6 +1,7 @@
 using Application.Contract.Order.Commands;
 using Application.Contract.Order.Queries;
 using Application.Contract.Order.Responses;
+using Application.Contract.Enums;
 using Client.Infrastructure.Services.Cart.Models;
 using Client.Infrastructure.Services.HttpClient;
 using System.Linq;
@@ -39,5 +40,11 @@ public class OrderService(IHttpClientService httpClient) : IOrderService
     {
         var res = await httpClient.GetFromJsonAsync<OrderResponse>($"/api/order/GetOrder?Slug={slug}");
         return res.Success ? res.Response : null;
+    }
+
+    public async Task UpdateStatusAsync(string slug, OrderStatus status)
+    {
+        var command = new UpdateOrderStatusCommand { Slug = slug, Status = status };
+        await httpClient.PutAsJsonAsync("/api/order", command);
     }
 }

--- a/src/Client/Client.Infrastructure/Services/Order/OrderService.cs
+++ b/src/Client/Client.Infrastructure/Services/Order/OrderService.cs
@@ -1,0 +1,43 @@
+using Application.Contract.Order.Commands;
+using Application.Contract.Order.Queries;
+using Application.Contract.Order.Responses;
+using Client.Infrastructure.Services.Cart.Models;
+using Client.Infrastructure.Services.HttpClient;
+using System.Linq;
+
+namespace Client.Infrastructure.Services.Order;
+
+public class OrderService(IHttpClientService httpClient) : IOrderService
+{
+    public async Task<string?> CreateAsync(string shopSlug, IEnumerable<CartItemDto> items)
+    {
+        var command = new CreateOrderCommand
+        {
+            ShopSlug = shopSlug,
+            Items = items.Select(i => new CreateOrderItem
+            {
+                ProductSlug = i.ProductSlug,
+                Quantity = i.Quantity,
+                SelectedVolume = i.SelectedVolume
+            }).ToList()
+        };
+
+        var result = await httpClient.PostAsJsonAsync<string>("/api/order", command);
+        return result.Success ? result.Response : null;
+    }
+
+    public async Task<List<OrderResponse>> GetAsync(string shopSlug)
+    {
+        var url = string.IsNullOrEmpty(shopSlug)
+            ? "/api/order/GetOrders"
+            : $"/api/order/GetOrders?ShopSlug={shopSlug}";
+        var res = await httpClient.GetFromJsonAsync<List<OrderResponse>>(url);
+        return res.Success ? res.Response ?? [] : [];
+    }
+
+    public async Task<OrderResponse?> GetAsyncBySlug(string slug)
+    {
+        var res = await httpClient.GetFromJsonAsync<OrderResponse>($"/api/order/GetOrder?Slug={slug}");
+        return res.Success ? res.Response : null;
+    }
+}

--- a/src/Client/Client.Infrastructure/Services/Shop/IShopService.cs
+++ b/src/Client/Client.Infrastructure/Services/Shop/IShopService.cs
@@ -1,0 +1,9 @@
+using Application.Contract.Shops.Queries;
+using Application.Contract.Shops.Responses;
+
+namespace Client.Infrastructure.Services.Shop;
+
+public interface IShopService
+{
+    Task<List<ShopResponse>> GetShopsAsync();
+}

--- a/src/Client/Client.Infrastructure/Services/Shop/ShopService.cs
+++ b/src/Client/Client.Infrastructure/Services/Shop/ShopService.cs
@@ -1,0 +1,13 @@
+using Application.Contract.Shops.Responses;
+using Client.Infrastructure.Services.HttpClient;
+
+namespace Client.Infrastructure.Services.Shop;
+
+public class ShopService(IHttpClientService httpClient) : IShopService
+{
+    public async Task<List<ShopResponse>> GetShopsAsync()
+    {
+        var res = await httpClient.GetFromJsonAsync<List<ShopResponse>>("/api/shop/GetShops");
+        return res.Success ? res.Response ?? [] : [];
+    }
+}

--- a/src/Client/Client/Layout/AppBar.razor
+++ b/src/Client/Client/Layout/AppBar.razor
@@ -15,6 +15,7 @@
     <MudHidden Breakpoint="Breakpoint.SmAndDown">
         <MudButton Variant="Variant.Text" OnClick="@(() => Navigation.NavigateTo("/category"))">Категория</MudButton>
         <MudButton Variant="Variant.Text" OnClick="@(() => Navigation.NavigateTo("/products"))">Продукты</MudButton>
+        <MudButton Variant="Variant.Text" OnClick="@(() => Navigation.NavigateTo("/orders"))">Заказы</MudButton>
         <MudButton Variant="Variant.Text" OnClick="@(() => Navigation.NavigateTo("/about"))">О нас</MudButton>
         <MudButton Variant="Variant.Text" OnClick="@(() => Navigation.NavigateTo("/contact"))">Контакты</MudButton>
     </MudHidden>

--- a/src/Client/Client/Layout/NavMenu.razor
+++ b/src/Client/Client/Layout/NavMenu.razor
@@ -1,7 +1,7 @@
 ﻿@using Application.Contract.Identity
 <MudNavMenu>
     <CascadingAuthenticationState>
-        <AuthorizeView Roles="@ApplicationRoles.Administrator">
+        <AuthorizeView Roles="@($"{ApplicationRoles.Administrator}, {ApplicationRoles.Salesman}")">
             <MudText Typo="Typo.subtitle2" Color="Color.Primary" Class="ml-4 my-3">
                 Админка
             </MudText>
@@ -13,6 +13,9 @@
             </MudNavLink>
             <MudNavLink Href="/admin/shops" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Shop">
                 Магазины
+            </MudNavLink>
+            <MudNavLink Href="/admin/orders" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.List">
+                Заказы
             </MudNavLink>
         </AuthorizeView>
     </CascadingAuthenticationState>

--- a/src/Client/Client/Pages/Admin/Orders/Orders.razor
+++ b/src/Client/Client/Pages/Admin/Orders/Orders.razor
@@ -1,0 +1,48 @@
+@page "/admin/orders"
+@using Application.Contract.Enums
+@using Application.Contract.Order.Responses
+@using Client.Infrastructure.Services.Order
+@using MudBlazor
+@inject IOrderService OrderService
+@inject ISnackbar Snackbar
+
+<MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
+    <MudText Typo="Typo.h4" Align="Align.Center" Class="mb-4">Заказы</MudText>
+    <MudTable Items="_orders" Hover="true" Dense="true">
+        <HeaderContent>
+            <MudTh>Номер</MudTh>
+            <MudTh>Магазин</MudTh>
+            <MudTh>Статус</MudTh>
+            <MudTh Class="text-right">Сумма</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>@context.Slug</MudTd>
+            <MudTd>@context.ShopSlug</MudTd>
+            <MudTd>@context.Status</MudTd>
+            <MudTd Class="text-right">@context.Sum ₽</MudTd>
+            <MudTd>
+                @if (context.Status != OrderStatus.Issued)
+                {
+                    <MudButton Size="Size.Small" Color="Color.Primary" OnClick="() => UpdateAsync(context)">Выдать</MudButton>
+                }
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+</MudContainer>
+
+@code {
+    private List<OrderResponse> _orders = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _orders = await OrderService.GetAsync(string.Empty);
+    }
+
+    private async Task UpdateAsync(OrderResponse order)
+    {
+        await OrderService.UpdateStatusAsync(order.Slug, OrderStatus.Issued);
+        order.Status = OrderStatus.Issued;
+        Snackbar.Add("Статус обновлен", Severity.Success);
+    }
+}

--- a/src/Client/Client/Pages/Clients/Cart.razor
+++ b/src/Client/Client/Pages/Clients/Cart.razor
@@ -2,6 +2,7 @@
 @using Client.Infrastructure.Services.Cart
 @using Client.Infrastructure.Services.Cart.Models
 @inject ICartService CartService
+@inject NavigationManager Navigation
 @implements IDisposable
 
 <MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
@@ -123,7 +124,7 @@
 
             <MudButton Variant="Variant.Filled" Color="Color.Primary"
                        FullWidth="true" Size="Size.Large"
-                       Disabled="@(_items.Count == 0)">
+                       Disabled="@(_items.Count == 0)" OnClick="@(() => Navigation.NavigateTo("/checkout"))">
                 Перейти к оформлению
             </MudButton>
         </MudPaper>

--- a/src/Client/Client/Pages/Clients/Checkout.razor
+++ b/src/Client/Client/Pages/Clients/Checkout.razor
@@ -4,6 +4,7 @@
 @using Client.Infrastructure.Services.Order
 @using Client.Infrastructure.Services.Shop
 @using Application.Contract.Shops.Responses
+@using System.Linq
 @inject ICartService CartService
 @inject IOrderService OrderService
 @inject IShopService ShopService
@@ -54,6 +55,7 @@
         _items = cart?.Orders ?? [];
         _total = _items.Sum(i => i.Quantity * (i.DiscountPrice ?? i.Price));
         _shops = await ShopService.GetShopsAsync();
+        _shop ??= _shops.FirstOrDefault()?.Slug;
     }
 
     private async Task CreateOrder()

--- a/src/Client/Client/Pages/Clients/Checkout.razor
+++ b/src/Client/Client/Pages/Clients/Checkout.razor
@@ -1,0 +1,70 @@
+@page "/checkout"
+@using Client.Infrastructure.Services.Cart
+@using Client.Infrastructure.Services.Cart.Models
+@using Client.Infrastructure.Services.Order
+@using Client.Infrastructure.Services.Shop
+@using Application.Contract.Shops.Responses
+@inject ICartService CartService
+@inject IOrderService OrderService
+@inject IShopService ShopService
+@inject NavigationManager Navigation
+@inject MudBlazor.ISnackbar Snackbar
+
+<MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
+    <MudText Typo="Typo.h4" Align="Align.Center" Class="mb-4">Оформление заказа</MudText>
+
+    <MudSelect T="string" Label="Магазин" @bind-Value="_shop" Class="mb-4">
+        @foreach (var s in _shops)
+        {
+            <MudSelectItem Value="@s.Slug">@s.Address</MudSelectItem>
+        }
+    </MudSelect>
+
+    <MudTable Items="_items" Dense="true">
+        <HeaderContent>
+            <MudTh>Товар</MudTh>
+            <MudTh>Кол-во</MudTh>
+            <MudTh Class="text-right">Сумма</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>@context.ProductName</MudTd>
+            <MudTd>@context.Quantity</MudTd>
+            <MudTd Class="text-right">@((context.DiscountPrice ?? context.Price) * context.Quantity) ₽</MudTd>
+        </RowTemplate>
+    </MudTable>
+
+    <MudDivider Class="my-2" />
+    <MudText Typo="Typo.h6" Align="Align.Right">Итого: @_total ₽</MudText>
+
+    <MudButton Color="Color.Primary" Variant="Variant.Filled" Class="mt-4"
+               Disabled="@(_items.Count==0 || string.IsNullOrEmpty(_shop))" OnClick="CreateOrder">
+        Оформить
+    </MudButton>
+</MudContainer>
+
+@code {
+    private List<CartItemDto> _items = new();
+    private List<ShopResponse> _shops = new();
+    private string? _shop;
+    private decimal _total;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var cart = await CartService.GetCartAsync();
+        _items = cart?.Orders ?? [];
+        _total = _items.Sum(i => i.Quantity * (i.DiscountPrice ?? i.Price));
+        _shops = await ShopService.GetShopsAsync();
+    }
+
+    private async Task CreateOrder()
+    {
+        if (string.IsNullOrEmpty(_shop)) return;
+        var slug = await OrderService.CreateAsync(_shop, _items);
+        if (slug != null)
+        {
+            await CartService.ClearAsync();
+            Snackbar.Add("Заказ оформлен", MudBlazor.Severity.Success);
+            Navigation.NavigateTo("/orders");
+        }
+    }
+}

--- a/src/Client/Client/Pages/Clients/Orders.razor
+++ b/src/Client/Client/Pages/Clients/Orders.razor
@@ -1,0 +1,30 @@
+@page "/orders"
+@using Client.Infrastructure.Services.Order
+@inject IOrderService OrderService
+@using Application.Contract.Order.Responses
+
+<MudContainer MaxWidth="MaxWidth.False" Class="mt-4">
+    <MudText Typo="Typo.h4" Align="Align.Center" Class="mb-4">Мои заказы</MudText>
+    <MudTable Items="_orders" Dense="true">
+        <HeaderContent>
+            <MudTh>Номер</MudTh>
+            <MudTh>Статус</MudTh>
+            <MudTh Class="text-right">Сумма</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>@context.Slug</MudTd>
+            <MudTd>@context.Status</MudTd>
+            <MudTd Class="text-right">@context.Sum ₽</MudTd>
+        </RowTemplate>
+    </MudTable>
+</MudContainer>
+
+@code {
+    private List<OrderResponse> _orders = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        // In this demo we just get orders without shop filter
+        _orders = await OrderService.GetAsync(string.Empty);
+    }
+}

--- a/src/Domain/Entities/Order.cs
+++ b/src/Domain/Entities/Order.cs
@@ -1,0 +1,18 @@
+using Domain.Enums;
+
+namespace Domain.Entities;
+
+public sealed class Order : BaseEntity
+{
+    public required string Slug { get; set; }
+    public List<OrderItem>? OrderItems { get; set; }
+
+    public Guid ShopId { get; set; }
+    public Shop? Shop { get; set; }
+    public string? ShopSlug { get; set; }
+
+    public Guid CustomerId { get; set; }
+    public ApplicationUser? Customer { get; set; }
+
+    public OrderStatus Status { get; set; }
+}

--- a/src/Domain/Entities/OrderItem.cs
+++ b/src/Domain/Entities/OrderItem.cs
@@ -1,0 +1,19 @@
+using Domain.Enums;
+
+namespace Domain.Entities;
+
+public sealed class OrderItem : BaseEntity
+{
+    public Guid OrderId { get; set; }
+    public Order? Order { get; set; }
+    public required string OrderSlug { get; set; }
+
+    public Guid ProductId { get; set; }
+    public Product? Product { get; set; }
+    public required string ProductSlug { get; set; }
+
+    public int Quantity { get; set; }
+    public decimal SummaryPrice { get; set; }
+
+    public OrderStatus Status { get; set; }
+}

--- a/src/Infrastructure/Persistence/Contexts/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/Contexts/ApplicationDbContext.cs
@@ -15,6 +15,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<ShopOrder> ShopsOrders { get; set; }
     public new DbSet<ApplicationUser> Users { get; set; }
     public DbSet<CartItem> CartItems { get; set; }
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<OrderItem> OrderItems { get; set; }
     public DbSet<Shop> Shops { get; set; }
     public DbSet<ShopOrder> ShopOrders { get; set; }
 }

--- a/src/WebApi/Controllers/OrderController.cs
+++ b/src/WebApi/Controllers/OrderController.cs
@@ -1,5 +1,6 @@
 using Application.Contract.Order.Commands;
 using Application.Contract.Order.Queries;
+using Application.Contract.Identity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -27,5 +28,13 @@ public class OrderController : ApiControllerBase
     {
         var response = await Mediator.Send(query);
         return Ok(response);
+    }
+
+    [HttpPut]
+    [Authorize(Roles = ApplicationRoles.Salesman + "," + ApplicationRoles.Administrator)]
+    public async Task<IActionResult> UpdateOrderStatus([FromBody] UpdateOrderStatusCommand command)
+    {
+        await Mediator.Send(command);
+        return Ok();
     }
 }

--- a/src/WebApi/Controllers/OrderController.cs
+++ b/src/WebApi/Controllers/OrderController.cs
@@ -1,0 +1,31 @@
+using Application.Contract.Order.Commands;
+using Application.Contract.Order.Queries;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.Controllers;
+
+[Authorize]
+public class OrderController : ApiControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> CreateOrder([FromBody] CreateOrderCommand command)
+    {
+        var response = await Mediator.Send(command);
+        return Ok(response);
+    }
+
+    [HttpGet(nameof(GetOrder))]
+    public async Task<IActionResult> GetOrder([FromQuery] GetOrderQuery query)
+    {
+        var response = await Mediator.Send(query);
+        return Ok(response);
+    }
+
+    [HttpGet(nameof(GetOrders))]
+    public async Task<IActionResult> GetOrders([FromQuery] GetOrdersQuery query)
+    {
+        var response = await Mediator.Send(query);
+        return Ok(response);
+    }
+}


### PR DESCRIPTION
## Summary
- implement new order creation command and handler
- add order/shops services on client
- add checkout and orders pages
- wire up navigation for orders and checkout

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873de1d33448330be55e5c73fc64c5e