### PR TITLE
Add admin editable site settings

### DIFF
--- a/src/Application.Contract/SiteSettings/Commands/UpdateSiteSettingCommand.cs
+++ b/src/Application.Contract/SiteSettings/Commands/UpdateSiteSettingCommand.cs
@@ -1,0 +1,13 @@
+namespace Application.Contract.SiteSettings.Commands;
+
+public class UpdateSiteSettingCommand : IRequest<Unit>
+{
+    public string? PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public string? Address { get; set; }
+    public string? TelegramLink { get; set; }
+    public string? WhatsAppLink { get; set; }
+    public string? InstagramLink { get; set; }
+    public string? FacebookLink { get; set; }
+    public string? Copyright { get; set; }
+}

--- a/src/Application.Contract/SiteSettings/Queries/GetSiteSettingQuery.cs
+++ b/src/Application.Contract/SiteSettings/Queries/GetSiteSettingQuery.cs
@@ -1,0 +1,7 @@
+using Application.Contract.SiteSettings.Responses;
+
+namespace Application.Contract.SiteSettings.Queries;
+
+public class GetSiteSettingQuery : IRequest<SiteSettingResponse>
+{
+}

--- a/src/Application.Contract/SiteSettings/Responses/SiteSettingResponse.cs
+++ b/src/Application.Contract/SiteSettings/Responses/SiteSettingResponse.cs
@@ -1,0 +1,13 @@
+namespace Application.Contract.SiteSettings.Responses;
+
+public class SiteSettingResponse
+{
+    public string? PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public string? Address { get; set; }
+    public string? TelegramLink { get; set; }
+    public string? WhatsAppLink { get; set; }
+    public string? InstagramLink { get; set; }
+    public string? FacebookLink { get; set; }
+    public string? Copyright { get; set; }
+}

--- a/src/Application/Common/Interfaces/Contexts/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/Contexts/IApplicationDbContext.cs
@@ -15,4 +15,5 @@ public interface IApplicationDbContext
     public DbSet<CartItem> CartItems { get; set; }
     public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     public DbSet<ApplicationUser> Users { get; set; }
+    public DbSet<SiteSetting> SiteSettings { get; set; }
 }

--- a/src/Application/Features/SiteSettings/Commands/UpdateSiteSettingCommandHandler.cs
+++ b/src/Application/Features/SiteSettings/Commands/UpdateSiteSettingCommandHandler.cs
@@ -1,0 +1,31 @@
+using Application.Common.Interfaces.Contexts;
+using Application.Contract.SiteSettings.Commands;
+using AutoMapper;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.SiteSettings.Commands;
+
+public class UpdateSiteSettingCommandHandler(IApplicationDbContext context, IMapper mapper)
+    : IRequestHandler<UpdateSiteSettingCommand, Unit>
+{
+    public async Task<Unit> Handle(UpdateSiteSettingCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await context.SiteSettings.FirstOrDefaultAsync(cancellationToken);
+        if (entity is null)
+        {
+            entity = new SiteSetting
+            {
+                PhoneNumber = string.Empty,
+                Email = string.Empty,
+                Address = string.Empty
+            };
+            await context.SiteSettings.AddAsync(entity, cancellationToken);
+        }
+
+        mapper.Map(request, entity);
+        await context.SaveChangesAsync(cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/src/Application/Features/SiteSettings/Queries/GetSiteSettingQueryHandler.cs
+++ b/src/Application/Features/SiteSettings/Queries/GetSiteSettingQueryHandler.cs
@@ -1,0 +1,18 @@
+using Application.Common.Interfaces.Contexts;
+using Application.Contract.SiteSettings.Queries;
+using Application.Contract.SiteSettings.Responses;
+using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.SiteSettings.Queries;
+
+public class GetSiteSettingQueryHandler(IApplicationDbContext context, IMapper mapper)
+    : IRequestHandler<GetSiteSettingQuery, SiteSettingResponse>
+{
+    public async Task<SiteSettingResponse> Handle(GetSiteSettingQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await context.SiteSettings.FirstOrDefaultAsync(cancellationToken);
+        return entity is null ? new SiteSettingResponse() : mapper.Map<SiteSettingResponse>(entity);
+    }
+}

--- a/src/Application/Features/SiteSettings/SiteSettingProfile.cs
+++ b/src/Application/Features/SiteSettings/SiteSettingProfile.cs
@@ -1,0 +1,15 @@
+using Application.Contract.SiteSettings.Commands;
+using Application.Contract.SiteSettings.Responses;
+using AutoMapper;
+using Domain.Entities;
+
+namespace Application.Features.SiteSettings;
+
+public class SiteSettingProfile : Profile
+{
+    public SiteSettingProfile()
+    {
+        CreateMap<SiteSetting, SiteSettingResponse>();
+        CreateMap<UpdateSiteSettingCommand, SiteSetting>();
+    }
+}

--- a/src/Client/Client.Infrastructure/Services/DependencyInitializer.cs
+++ b/src/Client/Client.Infrastructure/Services/DependencyInitializer.cs
@@ -5,6 +5,7 @@ using Client.Infrastructure.Services.Cart;
 using Client.Infrastructure.Services.Price;
 using Client.Infrastructure.Services.Product;
 using Client.Infrastructure.Services.Shop;
+using Client.Infrastructure.Services.Settings;
 using Client.Infrastructure.Services.Validation;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,7 +23,8 @@ public static class DependencyInitializer
             .AddScoped<IPriceCalculatorService, PriceCalculatorService>()
             .AddScoped<IHttpClientService, HttpClientService>()
             .AddScoped<IValidationService, ValidationService>()
-            .AddScoped<IShopService, ShopService>();
+            .AddScoped<IShopService, ShopService>()
+            .AddScoped<ISettingsService, SettingsService>();
 
     }
 }

--- a/src/Client/Client.Infrastructure/Services/Settings/ISettingsService.cs
+++ b/src/Client/Client.Infrastructure/Services/Settings/ISettingsService.cs
@@ -1,0 +1,10 @@
+using Application.Contract.SiteSettings.Commands;
+using Application.Contract.SiteSettings.Responses;
+
+namespace Client.Infrastructure.Services.Settings;
+
+public interface ISettingsService
+{
+    Task<SiteSettingResponse?> GetAsync(CancellationToken ct = default);
+    Task<bool> UpdateAsync(UpdateSiteSettingCommand command, CancellationToken ct = default);
+}

--- a/src/Client/Client.Infrastructure/Services/Settings/SettingsService.cs
+++ b/src/Client/Client.Infrastructure/Services/Settings/SettingsService.cs
@@ -1,0 +1,22 @@
+using Application.Contract.SiteSettings.Commands;
+using Application.Contract.SiteSettings.Responses;
+using Client.Infrastructure.Services.HttpClient;
+
+namespace Client.Infrastructure.Services.Settings;
+
+public sealed class SettingsService(IHttpClientService http) : ISettingsService
+{
+    private const string BaseUrl = "/api/SiteSetting";
+
+    public async Task<SiteSettingResponse?> GetAsync(CancellationToken ct = default)
+    {
+        var res = await http.GetFromJsonAsync<SiteSettingResponse>(BaseUrl);
+        return res.Success ? res.Response : null;
+    }
+
+    public async Task<bool> UpdateAsync(UpdateSiteSettingCommand command, CancellationToken ct = default)
+    {
+        var res = await http.PutAsJsonAsync(BaseUrl, command);
+        return res.Success;
+    }
+}

--- a/src/Client/Client/Layout/AppFooter.razor
+++ b/src/Client/Client/Layout/AppFooter.razor
@@ -1,14 +1,16 @@
+@using Application.Contract.SiteSettings.Responses
+@using Client.Infrastructure.Services.Settings
+
 <MudPaper Elevation="10" Style="margin-top: 100px; padding: 2rem;position: relative; z-index: 2;">
     <MudContainer MaxWidth="MaxWidth.ExtraExtraLarge">
         <MudGrid>
             <!-- Контактная информация -->
             <MudItem xs="12" sm="6" md="3" Class="d-flex flex-column flex-grow-1 gap-3">
                 <MudText Typo="Typo.h6" Class="footer-section-title">Контакты</MudText>
-                <MudText Typo="Typo.body1">Телефон: <a href="tel:+79011235500" class="footer-link">+7-901-123-55-00</a>
+                <MudText Typo="Typo.body1">Телефон: <a href="tel:@_setting?.PhoneNumber" class="footer-link">@_setting?.PhoneNumber</a>
                 </MudText>
-                <MudText Typo="Typo.body1">Email:<a href="mailto:info@example.com"
-                                                    class="footer-link">info@example.com</a></MudText>
-                <MudText Typo="Typo.body1">Адрес: Тверь, Улица Пржевальского<br>Дом 68с1</MudText>
+                <MudText Typo="Typo.body1">Email:<a href="mailto:@_setting?.Email" class="footer-link">@_setting?.Email</a></MudText>
+                <MudText Typo="Typo.body1">Адрес: @_setting?.Address</MudText>
             </MudItem>
 
             <!-- Быстрые ссылки -->
@@ -27,12 +29,12 @@
                 <MudText Typo="Typo.h6" Class="footer-section-title">Мы в соцсетях</MudText>
                 <MudGrid Spacing="2" Justify="Justify.FlexStart" Style="margin-left: -15px;">
                     <MudIconButton Icon="@Icons.Custom.Brands.Telegram" Color="Color.Primary"
-                                   Href="https://t.me/yourprofile" Target="_blank"/>
+                                   Href="@_setting?.TelegramLink" Target="_blank"/>
                     <MudIconButton Icon="@Icons.Custom.Brands.WhatsApp" Color="Color.Primary"
-                                   Href="https://wa.me/79011235500" Target="_blank"/>
-                    <MudIconButton Icon="@Icons.Material.Filled.Phone" Color="Color.Primary" Href="tel:+79011235500"/>
+                                   Href="@_setting?.WhatsAppLink" Target="_blank"/>
+                    <MudIconButton Icon="@Icons.Material.Filled.Phone" Color="Color.Primary" Href="@($"tel:{_setting?.PhoneNumber}")"/>
                     <MudIconButton Icon="@Icons.Custom.Brands.Gmail" Color="Color.Primary"
-                                   Href="mailto:info@example.com"/>
+                                   Href="@($"mailto:{_setting?.Email}")"/>
                 </MudGrid>
             </MudItem>
 
@@ -40,9 +42,7 @@
             <!-- Копирайт -->
             <MudItem xs="12" sm="6" md="3" Class="d-flex flex-column flex-grow-1 gap-3">
                 <MudText Typo="Typo.h6" Class="footer-section-title">Информация</MudText>
-                <MudText Typo="Typo.body2" Style="margin-top: -10px">&copy; @DateTime.Now.Year Солнечный восток. Все
-                    права защищены.
-                </MudText>
+                <MudText Typo="Typo.body2" Style="margin-top: -10px">@_setting?.Copyright</MudText>
                 <MudText Typo="Typo.body2"><a href="/PrivacyPolicy" class="footer-link">Политика конфиденциальности</a>
                 </MudText>
                 <MudText Typo="Typo.body2"><a href="/TermsOfUse" class="footer-link">Условия использования</a></MudText>
@@ -69,4 +69,13 @@
 @code {
     [Parameter] public string? Class { get; set; }
     [Parameter] public string? Style { get; set; }
+
+    [Inject] private ISettingsService SettingsService { get; set; } = default!;
+
+    private SiteSettingResponse? _setting;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _setting = await SettingsService.GetAsync();
+    }
 }

--- a/src/Client/Client/Layout/NavMenu.razor
+++ b/src/Client/Client/Layout/NavMenu.razor
@@ -14,6 +14,9 @@
             <MudNavLink Href="/admin/shops" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Shop">
                 Магазины
             </MudNavLink>
+            <MudNavLink Href="/admin/settings" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Settings">
+                Настройки
+            </MudNavLink>
         </AuthorizeView>
     </CascadingAuthenticationState>
 </MudNavMenu>

--- a/src/Client/Client/Pages/Admin/Settings/Settings.razor
+++ b/src/Client/Client/Pages/Admin/Settings/Settings.razor
@@ -1,0 +1,55 @@
+@page "/admin/settings"
+@using Client.Infrastructure.Services.Settings
+@using Application.Contract.SiteSettings.Commands
+@using Application.Contract.SiteSettings.Responses
+@using MudBlazor
+@inject ISettingsService SettingsService
+@inject ISnackbar Snackbar
+
+<h3>Настройки сайта</h3>
+
+<MudForm @ref="_form">
+    <MudTextField @bind-Value="_model.PhoneNumber" Label="Телефон" />
+    <MudTextField @bind-Value="_model.Email" Label="Email" />
+    <MudTextField @bind-Value="_model.Address" Label="Адрес" />
+    <MudTextField @bind-Value="_model.TelegramLink" Label="Telegram" />
+    <MudTextField @bind-Value="_model.WhatsAppLink" Label="WhatsApp" />
+    <MudTextField @bind-Value="_model.InstagramLink" Label="Instagram" />
+    <MudTextField @bind-Value="_model.FacebookLink" Label="Facebook" />
+    <MudTextField @bind-Value="_model.Copyright" Label="Копирайт" />
+    <MudButton Variant="Variant.Filled" OnClick="UpdateAsync">Сохранить</MudButton>
+</MudForm>
+
+@code {
+    private readonly UpdateSiteSettingCommand _model = new();
+    private MudForm? _form;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var data = await SettingsService.GetAsync();
+        if (data is not null)
+        {
+            _model.PhoneNumber = data.PhoneNumber;
+            _model.Email = data.Email;
+            _model.Address = data.Address;
+            _model.TelegramLink = data.TelegramLink;
+            _model.WhatsAppLink = data.WhatsAppLink;
+            _model.InstagramLink = data.InstagramLink;
+            _model.FacebookLink = data.FacebookLink;
+            _model.Copyright = data.Copyright;
+        }
+    }
+
+    private async Task UpdateAsync()
+    {
+        await _form!.Validate();
+        if (_form.IsValid)
+        {
+            var success = await SettingsService.UpdateAsync(_model);
+            if (success)
+                Snackbar.Add("Сохранено", MudBlazor.Severity.Success);
+            else
+                Snackbar.Add("Ошибка при сохранении", MudBlazor.Severity.Error);
+        }
+    }
+}

--- a/src/Domain/Entities/SiteSetting.cs
+++ b/src/Domain/Entities/SiteSetting.cs
@@ -1,0 +1,13 @@
+namespace Domain.Entities;
+
+public sealed class SiteSetting : BaseEntity
+{
+    public required string PhoneNumber { get; set; }
+    public required string Email { get; set; }
+    public required string Address { get; set; }
+    public string? TelegramLink { get; set; }
+    public string? WhatsAppLink { get; set; }
+    public string? InstagramLink { get; set; }
+    public string? FacebookLink { get; set; }
+    public string? Copyright { get; set; }
+}

--- a/src/Infrastructure/Persistence/Contexts/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/Contexts/ApplicationDbContext.cs
@@ -17,4 +17,5 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<CartItem> CartItems { get; set; }
     public DbSet<Shop> Shops { get; set; }
     public DbSet<ShopOrder> ShopOrders { get; set; }
+    public DbSet<SiteSetting> SiteSettings { get; set; }
 }

--- a/src/WebApi/Controllers/SiteSettingController.cs
+++ b/src/WebApi/Controllers/SiteSettingController.cs
@@ -1,0 +1,26 @@
+using Application.Contract.Identity;
+using Application.Contract.SiteSettings.Commands;
+using Application.Contract.SiteSettings.Queries;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.Controllers;
+
+public class SiteSettingController : ApiControllerBase
+{
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetSetting()
+    {
+        var response = await Mediator.Send(new GetSiteSettingQuery());
+        return Ok(response);
+    }
+
+    [HttpPut]
+    [Authorize(Roles = ApplicationRoles.Administrator)]
+    public async Task<IActionResult> UpdateSetting([FromBody] UpdateSiteSettingCommand command)
+    {
+        await Mediator.Send(command);
+        return Ok();
+    }
+}


### PR DESCRIPTION
## Summary
- add `SiteSetting` entity to store footer data
- allow DB context to manage `SiteSetting`
- implement queries and commands for site settings
- expose `/api/SiteSetting` endpoints
- provide client service and admin page to edit settings
- load footer info from API
- include settings link in nav menu

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_687b3b3673ec83308c0f798ff41856e5