### PR TITLE
feat: add email confirmation via mailgun

### DIFF
--- a/src/Application.Contract/Auth/ConfirmEmailResult.cs
+++ b/src/Application.Contract/Auth/ConfirmEmailResult.cs
@@ -1,0 +1,3 @@
+namespace Application.Contract.Auth;
+
+public record ConfirmEmailResult(string Status);

--- a/src/Application.Contract/Auth/ResendEmailConfirmationRequest.cs
+++ b/src/Application.Contract/Auth/ResendEmailConfirmationRequest.cs
@@ -1,0 +1,3 @@
+namespace Application.Contract.Auth;
+
+public record ResendEmailConfirmationRequest(string Email);

--- a/src/Application/Auth/IEmailConfirmationSender.cs
+++ b/src/Application/Auth/IEmailConfirmationSender.cs
@@ -1,0 +1,10 @@
+using Domain.Entities;
+
+namespace Application.Auth;
+
+public interface IEmailConfirmationSender
+{
+    Task SendConfirmationAsync(ApplicationUser user, CancellationToken ct = default);
+    Task<bool> ConfirmEmailAsync(Guid userId, string token, CancellationToken ct = default);
+    Task ResendConfirmationAsync(string email, CancellationToken ct = default);
+}

--- a/src/Application/Features/Users/Commands/LoginUserCommandHandler.cs
+++ b/src/Application/Features/Users/Commands/LoginUserCommandHandler.cs
@@ -35,6 +35,9 @@ public class LoginUserCommandHandler(IJwtTokenService jwtTokenService, UserManag
         if (await userManager.CheckPasswordAsync(user, request.Password) == false)
             throw new UnauthorizedAccessException("Неправильный пароль!");
 
+        if (!user.EmailConfirmed && !string.IsNullOrEmpty(user.Email))
+            throw new UnauthorizedAccessException("Email не подтвержден.");
+
 
         var claims = new List<Claim>
         {

--- a/src/Application/Features/Users/Commands/RegisterUserCommandHandler.cs
+++ b/src/Application/Features/Users/Commands/RegisterUserCommandHandler.cs
@@ -4,6 +4,7 @@ using Application.Common.Exceptions;
 using Application.Common.Interfaces.Contexts;
 using Application.Contract.User.Commands;
 using Domain.Entities;
+using Application.Auth;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -12,7 +13,8 @@ namespace Application.Features.Users.Commands;
 
 public class RegisterUserCommandHandler(
     UserManager<ApplicationUser> userManager,
-    IApplicationDbContext context)
+    IApplicationDbContext context,
+    IEmailConfirmationSender emailConfirmationSender)
     : IRequestHandler<RegisterUserCommand, string>
 {
     public async Task<string> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
@@ -62,6 +64,8 @@ public class RegisterUserCommandHandler(
 
         result.ThrowBadRequestIfError();
         await context.SaveChangesAsync(cancellationToken);
+
+        await emailConfirmationSender.SendConfirmationAsync(user, cancellationToken);
 
         return user.UserName!;
     }

--- a/src/Client/Client.Infrastructure/Services/Auth/AuthService.cs
+++ b/src/Client/Client.Infrastructure/Services/Auth/AuthService.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Contract.User.Commands;
 using Application.Contract.User.Responses;
+using Application.Contract.Auth;
 using Client.Infrastructure.Auth;
 using Client.Infrastructure.Services.HttpClient;
 using Microsoft.AspNetCore.Components;
@@ -28,6 +29,18 @@ public class AuthService(IHttpClientService httpClient,
     {
         var response = await httpClient.PostAsJsonAsync("/api/user/register", command);
         return response.Success;
+    }
+
+    public async Task ResendConfirmationAsync(string email)
+    {
+        await httpClient.PostAsJsonAsync("/api/auth/resend-email-confirmation", new { email });
+    }
+
+    public async Task<bool> ConfirmEmailAsync(string userId, string token)
+    {
+        var result = await httpClient.GetFromJsonAsync<ConfirmEmailResult>(
+            $"/api/auth/confirm-email?userId={userId}&token={token}");
+        return result.Success && result.Response?.Status == "success";
     }
 
     public async Task LogoutAsync(bool navigateToHome = false)

--- a/src/Client/Client.Infrastructure/Services/Auth/IAuthService.cs
+++ b/src/Client/Client.Infrastructure/Services/Auth/IAuthService.cs
@@ -6,5 +6,7 @@ public interface IAuthService
 {
     public Task<bool> LoginAsync(LoginUserCommand command, string? returnUrl =  null);
     public Task<bool> RegisterAsync(RegisterUserCommand command, string? returnUrl = null);
+    Task ResendConfirmationAsync(string email);
+    Task<bool> ConfirmEmailAsync(string userId, string token);
     Task LogoutAsync(bool navigateToHome = false);
 }

--- a/src/Infrastructure/DependencyInitializer.cs
+++ b/src/Infrastructure/DependencyInitializer.cs
@@ -7,6 +7,8 @@ using Domain.Entities;
 using Infrastructure.Persistence;
 using Infrastructure.Persistence.Contexts;
 using Infrastructure.Services;
+using Infrastructure.Mail;
+using Infrastructure.Services.Auth;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -37,6 +39,9 @@ public static class DependencyInitializer
         services.AddSingleton<IDateTimeService, DateTimeService>();
         services.AddSingleton<IVolumeGroupService, VolumeGroupService>();
         services.AddScoped<IPushNotificationService, PushNotificationService>();
+        services.Configure<MailgunOptions>(configurations.GetSection("Mailgun"));
+        services.AddHttpClient<IMailSender, MailgunEmailSender>();
+        services.AddScoped<Application.Auth.IEmailConfirmationSender, IdentityEmailConfirmationSender>();
         services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(identityOptions =>
             {
                 identityOptions.ClaimsIdentity.RoleClaimType = ClaimTypes.Role;

--- a/src/Infrastructure/Mail/EmailTemplateRenderer.cs
+++ b/src/Infrastructure/Mail/EmailTemplateRenderer.cs
@@ -1,0 +1,20 @@
+using System.Text;
+
+namespace Infrastructure.Mail;
+
+public static class EmailTemplateRenderer
+{
+    public static string RenderEmailConfirmation(string confirmationLink, string? code = null)
+    {
+        var sb = new StringBuilder();
+        sb.Append("<html><body>");
+        sb.Append("<p>Здравствуйте!</p>");
+        sb.Append("<p>Для завершения регистрации подтвердите адрес электронной почты.</p>");
+        sb.Append($"<p><a href='{confirmationLink}'>Подтвердить e-mail</a></p>");
+        sb.Append($"<p>Если кнопка не работает, перейдите по ссылке: {confirmationLink}</p>");
+        if (code != null)
+            sb.Append($"<p>Код подтверждения: <b>{code}</b></p>");
+        sb.Append("</body></html>");
+        return sb.ToString();
+    }
+}

--- a/src/Infrastructure/Mail/IMailSender.cs
+++ b/src/Infrastructure/Mail/IMailSender.cs
@@ -1,0 +1,6 @@
+namespace Infrastructure.Mail;
+
+public interface IMailSender
+{
+    Task SendAsync(string to, string subject, string htmlBody, string? textBody = null, CancellationToken ct = default);
+}

--- a/src/Infrastructure/Mail/MailgunEmailSender.cs
+++ b/src/Infrastructure/Mail/MailgunEmailSender.cs
@@ -1,0 +1,62 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Mail;
+
+public class MailgunEmailSender : IMailSender
+{
+    private readonly HttpClient _httpClient;
+    private readonly MailgunOptions _options;
+    private readonly ILogger<MailgunEmailSender> _logger;
+
+    public MailgunEmailSender(HttpClient httpClient, IOptions<MailgunOptions> options, ILogger<MailgunEmailSender> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+
+        var auth = Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{_options.ApiKey}"));
+        _httpClient.BaseAddress = new Uri(_options.BaseUri.TrimEnd('/') + "/");
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", auth);
+    }
+
+    public async Task SendAsync(string to, string subject, string htmlBody, string? textBody = null, CancellationToken ct = default)
+    {
+        var content = new MultipartFormDataContent
+        {
+            { new StringContent($"{_options.FromName} <{_options.Sender}>", Encoding.UTF8), "from" },
+            { new StringContent(to, Encoding.UTF8), "to" },
+            { new StringContent(subject, Encoding.UTF8), "subject" },
+            { new StringContent(htmlBody, Encoding.UTF8), "html" }
+        };
+
+        if (!string.IsNullOrEmpty(textBody))
+            content.Add(new StringContent(textBody), "text");
+
+        try
+        {
+            var response = await _httpClient.PostAsync($"{_options.Domain}/messages", content, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogError("Mailgun send failed: {Status} {Body}", response.StatusCode, body);
+                throw new MailgunException("Failed to send email");
+            }
+
+            _logger.LogInformation("Mail sent to {Email}", to);
+        }
+        catch (Exception ex) when (ex is not MailgunException)
+        {
+            _logger.LogError(ex, "Error sending email");
+            throw new MailgunException("Failed to send email", ex);
+        }
+    }
+}
+
+public class MailgunException : Exception
+{
+    public MailgunException(string message) : base(message) { }
+    public MailgunException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Infrastructure/Mail/MailgunOptions.cs
+++ b/src/Infrastructure/Mail/MailgunOptions.cs
@@ -1,0 +1,11 @@
+namespace Infrastructure.Mail;
+
+public record MailgunOptions
+{
+    public required string ApiKey { get; init; }
+    public required string Domain { get; init; }
+    public required string Sender { get; init; }
+    public required string FromName { get; init; }
+    public string BaseUri { get; init; } = "https://api.mailgun.net/v3";
+    public required string ConfirmationUrlBase { get; init; }
+}

--- a/src/Infrastructure/Services/Auth/IdentityEmailConfirmationSender.cs
+++ b/src/Infrastructure/Services/Auth/IdentityEmailConfirmationSender.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using System.Linq;
+using Application.Auth;
+using Domain.Entities;
+using Infrastructure.Mail;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Services.Auth;
+
+public class IdentityEmailConfirmationSender : IEmailConfirmationSender
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IMailSender _mailSender;
+    private readonly MailgunOptions _options;
+    private readonly ILogger<IdentityEmailConfirmationSender> _logger;
+
+    public IdentityEmailConfirmationSender(UserManager<ApplicationUser> userManager,
+        IMailSender mailSender,
+        IOptions<MailgunOptions> options,
+        ILogger<IdentityEmailConfirmationSender> logger)
+    {
+        _userManager = userManager;
+        _mailSender = mailSender;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendConfirmationAsync(ApplicationUser user, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(user.Email))
+            return;
+
+        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+        var encoded = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(token));
+        var link = $"{_options.ConfirmationUrlBase}?userId={user.Id}&token={encoded}";
+        var html = EmailTemplateRenderer.RenderEmailConfirmation(link);
+        await _mailSender.SendAsync(user.Email, "Подтверждение регистрации", html, null, ct);
+    }
+
+    public async Task<bool> ConfirmEmailAsync(Guid userId, string token, CancellationToken ct = default)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString());
+        if (user == null)
+            return false;
+        var decoded = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(token));
+        var result = await _userManager.ConfirmEmailAsync(user, decoded);
+        if (result.Succeeded)
+        {
+            _logger.LogInformation("Email confirmed for {UserId}", userId);
+            return true;
+        }
+        _logger.LogWarning("Email confirmation failed for {UserId}: {Errors}", userId,
+            string.Join(",", result.Errors.Select(e => e.Description)));
+        return false;
+    }
+
+    public async Task ResendConfirmationAsync(string email, CancellationToken ct = default)
+    {
+        var user = await _userManager.FindByEmailAsync(email);
+        if (user == null || user.EmailConfirmed)
+            return;
+        await SendConfirmationAsync(user, ct);
+    }
+}

--- a/src/WebApi/Controllers/AuthController.cs
+++ b/src/WebApi/Controllers/AuthController.cs
@@ -1,0 +1,25 @@
+using Application.Auth;
+using Application.Contract.Auth;
+using Microsoft.AspNetCore.Mvc;
+using WebApi.Filters;
+
+namespace WebApi.Controllers;
+
+[CustomExceptionsFilter]
+[Route("api/[controller]")]
+public class AuthController(IEmailConfirmationSender emailConfirmationSender) : ControllerBase
+{
+    [HttpPost("resend-email-confirmation")]
+    public async Task<IActionResult> ResendEmailConfirmation([FromBody] ResendEmailConfirmationRequest request)
+    {
+        await emailConfirmationSender.ResendConfirmationAsync(request.Email, HttpContext.RequestAborted);
+        return Accepted();
+    }
+
+    [HttpGet("confirm-email")]
+    public async Task<ActionResult<ConfirmEmailResult>> ConfirmEmail([FromQuery] Guid userId, [FromQuery] string token)
+    {
+        var success = await emailConfirmationSender.ConfirmEmailAsync(userId, token, HttpContext.RequestAborted);
+        return Ok(new ConfirmEmailResult(success ? "success" : "invalid"));
+    }
+}

--- a/src/WebApi/appsettings.Development.json
+++ b/src/WebApi/appsettings.Development.json
@@ -22,5 +22,13 @@
     "Secret": "this is a secret!this is a secret!this is a secret!this is a secret!this is a secret!this is a secret!this is a secret!this is a secret!",
     "RefreshTokenValidityInDays": 30,
     "TokenValidityInDays": 2
+  },
+  "Mailgun": {
+    "ApiKey": "<env:MAILGUN_API_KEY>",
+    "Domain": "<env:MAILGUN_DOMAIN>",
+    "Sender": "noreply@yourdomain.com",
+    "FromName": "Солнечный Восток",
+    "BaseUri": "https://api.mailgun.net/v3",
+    "ConfirmationUrlBase": "https://localhost:5289/verify"
   }
 }

--- a/src/WebApi/appsettings.json
+++ b/src/WebApi/appsettings.json
@@ -21,4 +21,13 @@
     "Subject": "mailto:firuzisoboev@gmail.com"
   },
   "AllowedHosts": "*"
+  ,
+  "Mailgun": {
+    "ApiKey": "<env:MAILGUN_API_KEY>",
+    "Domain": "<env:MAILGUN_DOMAIN>",
+    "Sender": "noreply@yourdomain.com",
+    "FromName": "Солнечный Восток",
+    "BaseUri": "https://api.mailgun.net/v3",
+    "ConfirmationUrlBase": "https://localhost:5289/verify"
+  }
 }


### PR DESCRIPTION
## Summary
- add Mailgun options and sender to dispatch confirmation emails
- integrate email confirmation into registration and login flow
- expose API endpoints for resending and confirming email

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688f38c5253483309abafd903fdcd8ff